### PR TITLE
Convert mamma demo into reusable library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,64 @@
+# Mamma Spring Annotation
 
+`mamma` is a small Maven package that contributes a reusable Spring annotation,
+`@Mamma`, and the supporting aspect that prints your mama's name whenever an
+annotated method runs.
+
+## Building and installing the package
+
+```
+mvn clean install
+```
+
+The command installs the library in your local Maven repository so other
+projects can declare a dependency on it.
+
+## Using the annotation in Spring Boot
+
+Add the dependency to your application's `pom.xml`:
+
+```xml
+<dependency>
+    <groupId>com.example</groupId>
+    <artifactId>mamma</artifactId>
+    <version>0.1.0</version>
+</dependency>
+```
+
+`MammaAutoConfiguration` is published as a Spring Boot auto-configuration, so as
+soon as the dependency and the `spring-boot-starter-aop` starter are on the
+classpath the aspect is activated automatically.
+
+```java
+@Service
+class GreetingService {
+
+    @Mamma("Gloria")
+    public String greet(String name) {
+        return "Hello, " + name + "!";
+    }
+}
+```
+
+Each invocation of `greet` prints `greet's mama is Gloria!` to the console.
+
+## Using the annotation with the classic Spring container
+
+Import the provided `@EnableMamma` on a configuration class to register the
+aspect:
+
+```java
+@Configuration
+@EnableMamma
+class AppConfig {
+}
+```
+
+Once enabled you can annotate any Spring bean method with `@Mamma` and the
+aspect will shout out the configured mama name.
+
+## Running tests
+
+```
+mvn test
+```

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,74 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.example</groupId>
+    <artifactId>mamma</artifactId>
+    <version>0.1.0</version>
+    <name>mamma</name>
+    <description>Reusable Spring annotation that shouts out your mama</description>
+    <packaging>jar</packaging>
+
+    <properties>
+        <java.version>17</java.version>
+        <spring.version>6.1.6</spring.version>
+        <maven.compiler.release>${java.version}</maven.compiler.release>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-aop</artifactId>
+            <version>${spring.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>3.2.5</version>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-test</artifactId>
+            <version>${spring.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.11.0</version>
+                <configuration>
+                    <release>${maven.compiler.release}</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.2</version>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/main/java/com/example/mamma/annotations/Mamma.java
+++ b/src/main/java/com/example/mamma/annotations/Mamma.java
@@ -1,0 +1,19 @@
+package com.example.mamma.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation that prints your mama's name whenever the annotated method runs.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface Mamma {
+
+    /**
+     * The name of your mama to be printed by the aspect.
+     */
+    String value();
+}

--- a/src/main/java/com/example/mamma/aspects/MammaAspect.java
+++ b/src/main/java/com/example/mamma/aspects/MammaAspect.java
@@ -1,0 +1,18 @@
+package com.example.mamma.aspects;
+
+import com.example.mamma.annotations.Mamma;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+/**
+ * Aspect that reacts to {@link Mamma} annotations.
+ */
+@Aspect
+public class MammaAspect {
+
+    @Before("@annotation(mamma)")
+    public void announceMamma(JoinPoint joinPoint, Mamma mamma) {
+        String mamaName = mamma.value();
+        System.out.printf("%s's mama is %s!%n", joinPoint.getSignature().getName(), mamaName);
+    }
+}

--- a/src/main/java/com/example/mamma/autoconfigure/MammaAutoConfiguration.java
+++ b/src/main/java/com/example/mamma/autoconfigure/MammaAutoConfiguration.java
@@ -1,0 +1,21 @@
+package com.example.mamma.autoconfigure;
+
+import com.example.mamma.aspects.MammaAspect;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * Auto-configuration that registers the {@link MammaAspect} when Spring Boot is present.
+ */
+@AutoConfiguration
+@ConditionalOnClass(MammaAspect.class)
+public class MammaAutoConfiguration {
+
+    @Bean
+    @ConditionalOnMissingBean
+    public MammaAspect mammaAspect() {
+        return new MammaAspect();
+    }
+}

--- a/src/main/java/com/example/mamma/config/EnableMamma.java
+++ b/src/main/java/com/example/mamma/config/EnableMamma.java
@@ -1,0 +1,23 @@
+package com.example.mamma.config;
+
+import org.springframework.context.annotation.Import;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Activates the {@code @Mamma} aspect in a classic Spring application.
+ * <p>
+ * Users can place this annotation on a {@code @Configuration} class to
+ * register the {@link MammaConfiguration} that exposes the {@code MammaAspect}
+ * bean.
+ */
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(MammaConfiguration.class)
+public @interface EnableMamma {
+}

--- a/src/main/java/com/example/mamma/config/MammaConfiguration.java
+++ b/src/main/java/com/example/mamma/config/MammaConfiguration.java
@@ -1,0 +1,19 @@
+package com.example.mamma.config;
+
+import com.example.mamma.aspects.MammaAspect;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
+
+/**
+ * Standard Spring configuration that exposes the {@link MammaAspect} bean.
+ */
+@Configuration
+@EnableAspectJAutoProxy
+public class MammaConfiguration {
+
+    @Bean
+    public MammaAspect mammaAspect() {
+        return new MammaAspect();
+    }
+}

--- a/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.example.mamma.autoconfigure.MammaAutoConfiguration

--- a/src/test/java/com/example/mamma/MammaAspectTest.java
+++ b/src/test/java/com/example/mamma/MammaAspectTest.java
@@ -1,0 +1,59 @@
+package com.example.mamma;
+
+import com.example.mamma.annotations.Mamma;
+import com.example.mamma.config.MammaConfiguration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringJUnitConfig(classes = {MammaConfiguration.class, MammaAspectTest.TestConfig.class})
+class MammaAspectTest {
+
+    @Autowired
+    private GreetingService greetingService;
+
+    @Test
+    void mammaAnnotationPrintsName() {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        PrintStream originalOut = System.out;
+        PrintStream capture = new PrintStream(output, true);
+        System.setOut(capture);
+        try {
+            String greeting = greetingService.greet("Tester");
+
+            assertThat(greeting).isEqualTo("Hello, Tester!");
+        } finally {
+            System.setOut(originalOut);
+            capture.close();
+        }
+
+        assertThat(output.toString())
+                .contains("greet's mama is Gloria!")
+                .contains("Hello, Tester!");
+    }
+
+    static class GreetingService {
+
+        @Mamma("Gloria")
+        String greet(String name) {
+            String message = "Hello, " + name + "!";
+            System.out.println(message);
+            return message;
+        }
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        GreetingService greetingService() {
+            return new GreetingService();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- convert the project into a reusable Maven library that exposes the `@Mamma` annotation and supporting aspect
- add Spring Boot auto-configuration and an `@EnableMamma` switch for classic Spring applications
- refresh the documentation and tests to demonstrate how downstream projects consume the package

## Testing
- `mvn test` *(fails: network is unreachable while downloading Maven plugins)*

------
https://chatgpt.com/codex/tasks/task_e_68cbe5b769008332928abc1cd9ca2179